### PR TITLE
Fixes while installing the ed easy installer for release-6.0.0

### DIFF
--- a/helmcharts/inquirybb/values.yaml
+++ b/helmcharts/inquirybb/values.yaml
@@ -73,6 +73,10 @@ elasticsearch: &es
     annotations: *provisioningAnnotations
   persistence:
     size: 25Gi
+  sysctlImage:
+    registry: docker.io
+    repository: bitnami/bitnami-shell-archived
+    tag: 11-debian-11-r54
 
 cassandra: &cassandra
   enabled: true

--- a/helmcharts/knowledgebb/values.yaml
+++ b/helmcharts/knowledgebb/values.yaml
@@ -50,6 +50,10 @@ elasticsearch: &es
     "helm.sh/hook-weight": "-5"
   provisioning:
     annotations: *provisioningAnnotations
+  sysctlImage:
+    registry: docker.io
+    repository: bitnami/bitnami-shell-archived
+    tag: 11-debian-11-r54
 
 redis: &redis
   enabled: true

--- a/helmcharts/learnbb/values.yaml
+++ b/helmcharts/learnbb/values.yaml
@@ -65,6 +65,10 @@ elasticsearch: &es
     "helm.sh/hook-weight": "-5"
   provisioning:
     annotations: *provisioningAnnotations
+  sysctlImage:
+    registry: docker.io
+    repository: bitnami/bitnami-shell-archived
+    tag: 11-debian-11-r54
 
 redis: &redis
   enabled: true

--- a/helmcharts/obsrvbb/values.yaml
+++ b/helmcharts/obsrvbb/values.yaml
@@ -57,6 +57,10 @@ elasticsearch: &es
     "helm.sh/hook-weight": "-5"
   provisioning:
     annotations: *provisioningAnnotations
+  sysctlImage:
+    registry: docker.io
+    repository: bitnami/bitnami-shell-archived
+    tag: 11-debian-11-r54
 
 
 postgresql: &postgresql

--- a/terraform/azure/modules/aks/main.tf
+++ b/terraform/azure/modules/aks/main.tf
@@ -1,5 +1,6 @@
   provider "azurerm" {
     features {}
+    skip_provider_registration = true
   }
 
   provider "azuread" {

--- a/terraform/azure/modules/network/main.tf
+++ b/terraform/azure/modules/network/main.tf
@@ -1,5 +1,6 @@
 provider "azurerm" {
   features {}
+  skip_provider_registration = true
 }
 
 data "azurerm_subscription" "current" {}

--- a/terraform/azure/modules/storage/main.tf
+++ b/terraform/azure/modules/storage/main.tf
@@ -1,5 +1,6 @@
 provider "azurerm" {
   features {}
+  skip_provider_registration = true
 }
 
 data "azurerm_subscription" "current" {}


### PR DESCRIPTION
1st issue with the repository which was used by elasticsearch init pod helm chart where helm chart was not able to pull that image. We have checked the repo and image and this has been moved to repository.
2nd issue we have skipped provider registration as it was trying to install unnecessary providers. We can have one time instruction to install the providers. 