### PR TITLE
SBCOSS-589: system setting for account delete otp verification

### DIFF
--- a/postman-collection/collectionrelease700.json
+++ b/postman-collection/collectionrelease700.json
@@ -1111,6 +1111,50 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "25 - set setting - verifyOtpOnDelete",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{apikey}}"
+							},
+							{
+								"key": "x-authenticated-user-token",
+								"value": "{{access_token}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"request\": {\n        \"id\": \"verifyOtpOnDelete\",\n        \"field\": \"verifyOtpOnDelete\",\n        \"value\": \"true\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{host}}/api/data/v1/system/settings/set",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"data",
+								"v1",
+								"system",
+								"settings",
+								"set"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},


### PR DESCRIPTION
Configured a system setting for otp verification for delete account.
1. Using this setting we can enable/disable the otp verification while deleting the user account.