### PR TITLE
fix: Increase LMS service memory allocation to fix out of memory kill (OOMK)

### DIFF
--- a/helmcharts/global-resources.yaml
+++ b/helmcharts/global-resources.yaml
@@ -300,7 +300,7 @@ lms:
       memory: 100Mi
     limits:
       cpu: 1
-      memory: 1024Mi
+      memory: 1536Mi
 
 notification:
   resources:


### PR DESCRIPTION
## Summary
This PR updates the LMS service resource configuration to increase the memory allocation from **1Gi to 1.5Gi**.

### Reason for Change
- Recent code changes introduced a **fat JAR**, which increased the application size and memory footprint.