### PR TITLE
#SB-I403: fix: Nodebb v4 support changes

### DIFF
--- a/helmcharts/edbb/charts/kong-apis/configs/kong-apis.yaml
+++ b/helmcharts/edbb/charts/kong-apis/configs/kong-apis.yaml
@@ -9090,3 +9090,94 @@ kong_apis:
     config.limit_by: credential
   - name: request-size-limiting
     config.allowed_payload_size: "{{ .Values.medium_request_size_limit }}"
+
+# v3 APIs for discussions
+- name: createTopicOfDiscussionsV3
+  uris: "{{ .Values.discussions_prefix }}/v3/topics"
+  upstream_url: "{{ .Values.discussions_mw_service_url }}/v3/topics"
+  strip_uri: true
+  plugins:
+  - name: jwt
+  - name: cors
+  - {{ .Values.statsd_plugin | toYaml | nindent 4 | trim }}
+  - name: acl
+    config.whitelist:
+    - discussionCreate
+  - name: rate-limiting
+    config.policy: local
+    config.hour: "{{ .Values.medium_rate_limit_per_hour }}"
+    config.limit_by: credential
+  - name: request-size-limiting
+    config.allowed_payload_size: "{{ .Values.medium_request_size_limit }}"
+
+- name: createCategoryOfDiscussionV3
+  uris: "{{ .Values.discussions_prefix }}/v3/categories"
+  upstream_url: "{{ .Values.discussions_mw_service_url }}/v3/categories"
+  strip_uri: true
+  plugins:
+  - name: jwt
+  - name: cors
+  - {{ .Values.statsd_plugin | toYaml | nindent 4 | trim }}
+  - name: acl
+    config.whitelist:
+    - discussionCreate
+  - name: rate-limiting
+    config.policy: local
+    config.hour: "{{ .Values.medium_rate_limit_per_hour }}"
+    config.limit_by: credential
+  - name: request-size-limiting
+    config.allowed_payload_size: "{{ .Values.medium_request_size_limit }}"
+
+- name: createGroupsOfDiscussionV3
+  uris: "{{ .Values.discussions_prefix }}/v3/groups"
+  upstream_url: "{{ .Values.discussions_mw_service_url }}/v3/groups"
+  strip_uri: true
+  plugins:
+  - name: jwt
+  - name: cors
+  - {{ .Values.statsd_plugin | toYaml | nindent 4 | trim }}
+  - name: acl
+    config.whitelist:
+    - discussionCreate
+  - name: rate-limiting
+    config.policy: local
+    config.hour: "{{ .Values.medium_rate_limit_per_hour }}"
+    config.limit_by: credential
+  - name: request-size-limiting
+    config.allowed_payload_size: "{{ .Values.medium_request_size_limit }}"
+
+- name: createNewPostOfDiscussionV3
+  uris: "{{ .Values.discussions_prefix }}/v3/posts"
+  upstream_url: "{{ .Values.discussions_mw_service_url }}/v3/posts"
+  strip_uri: true
+  plugins:
+  - name: jwt
+  - name: cors
+  - {{ .Values.statsd_plugin | toYaml | nindent 4 | trim }}
+  - name: acl
+    config.whitelist:
+    - discussionCreate
+  - name: rate-limiting
+    config.policy: local
+    config.hour: "{{ .Values.medium_rate_limit_per_hour }}"
+    config.limit_by: credential
+  - name: request-size-limiting
+    config.allowed_payload_size: "{{ .Values.medium_request_size_limit }}"
+
+- name: createNewUserOfDiscussionV3
+  uris: "{{ .Values.discussions_prefix }}/v3/users"
+  upstream_url: "{{ .Values.discussions_mw_service_url }}/v3/users"
+  strip_uri: true
+  plugins:
+  - name: jwt
+  - name: cors
+  - {{ .Values.statsd_plugin | toYaml | nindent 4 | trim }}
+  - name: acl
+    config.whitelist:
+    - discussionCreate
+  - name: rate-limiting
+    config.policy: local
+    config.hour: "{{ .Values.medium_rate_limit_per_hour }}"
+    config.limit_by: credential
+  - name: request-size-limiting
+    config.allowed_payload_size: "{{ .Values.medium_request_size_limit }}"

--- a/helmcharts/edbb/charts/nodebb/configs/env.yaml
+++ b/helmcharts/edbb/charts/nodebb/configs/env.yaml
@@ -5,6 +5,8 @@
 NODE_OPTIONS: "1024"
 admin__password: nodebb{{ .Values.global.random_string }}
 admin__username: admin
+admin__password_confirm: nodebb{{ .Values.global.random_string }}
+admin__email: admin@example.com
 database: redis
 isCluster: "false"
 redis__database: '10'

--- a/helmcharts/edbb/charts/nodebb/templates/deployment.yaml
+++ b/helmcharts/edbb/charts/nodebb/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.args }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
+          {{- end }}
           {{- if .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/helmcharts/edbb/charts/nodebb/values.yaml
+++ b/helmcharts/edbb/charts/nodebb/values.yaml
@@ -10,6 +10,8 @@ image:
   pullSecrets: []
 
 args:
+  - /bin/sh
+  - -c
   - |
     ./nodebb build
     node loader.js --no-daemon --no-silent

--- a/helmcharts/edbb/charts/nodebb/values.yaml
+++ b/helmcharts/edbb/charts/nodebb/values.yaml
@@ -9,6 +9,11 @@ image:
   tag: release-5.0.0_RC1_1_v1.18.6
   pullSecrets: []
 
+args:
+  - |
+    ./nodebb build
+    node loader.js --no-daemon --no-silent
+
 podAnnotations: {}
 
 podSecurityContext:
@@ -68,7 +73,7 @@ autoscaling:
 livenessProbe:
   failureThreshold: 20
   httpGet:
-      path: /discussions/api/category/2
+      path: /discussions/api/forum/health
       port: 4567
   initialDelaySeconds: 45
   periodSeconds: 15
@@ -79,7 +84,7 @@ livenessProbe:
 readinessProbe:
   failureThreshold: 20
   httpGet:
-      path: /discussions/api/category/2
+      path: /discussions/api/forum/health
       port: 4567
   initialDelaySeconds: 45
   periodSeconds: 15

--- a/terraform/azure/template/install.sh
+++ b/terraform/azure/template/install.sh
@@ -117,7 +117,7 @@ function post_install_nodebb_plugins() {
     echo ">> Activating NodeBB plugins..."
     kubectl exec -n sunbird deploy/nodebb -- ./nodebb activate nodebb-plugin-create-forum
     kubectl exec -n sunbird deploy/nodebb -- ./nodebb activate nodebb-plugin-sunbird-oidc
-    kubectl exec -n sunbird deploy/nodebb -- ./nodebb activate nodebb-plugin-write-api
+    kubectl exec -n sunbird deploy/nodebb -- ./nodebb reset nodebb-plugin-write-api
 
     echo ">> Rebuilding NodeBB to apply plugin changes..."
     kubectl exec -n sunbird deploy/nodebb -- ./nodebb build

--- a/terraform/gcp/template/install.sh
+++ b/terraform/gcp/template/install.sh
@@ -127,7 +127,7 @@ function post_install_nodebb_plugins() {
     echo ">> Activating NodeBB plugins..."
     kubectl exec -n sunbird deploy/nodebb -- ./nodebb activate nodebb-plugin-create-forum
     kubectl exec -n sunbird deploy/nodebb -- ./nodebb activate nodebb-plugin-sunbird-oidc
-    kubectl exec -n sunbird deploy/nodebb -- ./nodebb activate nodebb-plugin-write-api
+    kubectl exec -n sunbird deploy/nodebb -- ./nodebb reset nodebb-plugin-write-api
 
     echo ">> Rebuilding NodeBB to apply plugin changes..."
     kubectl exec -n sunbird deploy/nodebb -- ./nodebb build


### PR DESCRIPTION
1. Nodebb v3 write api registration in kong, as the write api plugin is deprecated
2. Nodebb helmchart changes to support upgrades and build.